### PR TITLE
Feature add targets request

### DIFF
--- a/moira/api/resources/targets.py
+++ b/moira/api/resources/targets.py
@@ -1,4 +1,5 @@
 from twisted.internet import defer
+from twisted.web import http
 
 from moira.api.request import delayed
 from moira.api.resources.redis import RedisResouce
@@ -17,8 +18,9 @@ class Targets(RedisResouce):
     @defer.inlineCallbacks
     def render_GET(self, request):
         targets = yield self.db.getTargets()
-        if 'search' in request.args.keys():
-            targets_out = yield [t for t in targets if request.args['search'][0].encode("utf8") in t]
+        if 'name' not in request.args.keys():
+            request.setResponseCode(http.BAD_REQUEST)
+            request.finish()
         else:
-            targets_out = []
-        self.write_json(request, {"list": targets_out[0:3]})
+            targets_out = yield [t for t in targets if request.args['name'][0].encode("utf8") in t]
+            self.write_json(request, {"list": targets_out[0:3]})

--- a/moira/api/resources/targets.py
+++ b/moira/api/resources/targets.py
@@ -1,0 +1,24 @@
+from twisted.internet import defer
+
+from moira.api.request import delayed
+from moira.api.resources.redis import RedisResouce
+
+
+class Targets(RedisResouce):
+
+    def __init__(self, db):
+        RedisResouce.__init__(self, db)
+
+    def getChild(self, path, request):
+        if not path:
+            return self
+
+    @delayed
+    @defer.inlineCallbacks
+    def render_GET(self, request):
+        targets = yield self.db.getTargets()
+        if 'search' in request.args.keys():
+            targets_out = yield [t for t in targets if request.args['search'][0].encode("utf8") in t]
+        else:
+            targets_out = []
+        self.write_json(request, {"list": targets_out[0:3]})

--- a/moira/api/site.py
+++ b/moira/api/site.py
@@ -11,6 +11,7 @@ from moira.api.resources.subscription import Subscriptions
 from moira.api.resources.tags import Tags
 from moira.api.resources.trigger import Triggers
 from moira.api.resources.user import Login
+from moira.api.resources.targets import Targets
 
 
 class MoiraRequest(server.Request):
@@ -48,6 +49,7 @@ class Site(server.Site):
         prefix.putChild("subscription", Subscriptions(db))
         prefix.putChild("user", Login(db))
         prefix.putChild("notification", Notifications(db))
+        prefix.putChild("targets", Targets(db))
         server.Site.__init__(self, root)
 
     def _escape(self, s):

--- a/moira/config.py
+++ b/moira/config.py
@@ -24,7 +24,7 @@ except ImportError:
 
 CONFIG_PATH = '/etc/moira/config.yml'
 # CONFIG_PATH = '..\\pkg\\worker.yml'
-REDIS_HOST = "10.160.62.26"
+REDIS_HOST = "localhost"
 REDIS_PORT = 6379
 LOG_DIRECTORY = "stdout"
 HTTP_PORT = 8081

--- a/moira/config.py
+++ b/moira/config.py
@@ -23,7 +23,6 @@ except ImportError:
     ujson = None
 
 CONFIG_PATH = '/etc/moira/config.yml'
-# CONFIG_PATH = '..\\pkg\\worker.yml'
 REDIS_HOST = "localhost"
 REDIS_PORT = 6379
 LOG_DIRECTORY = "stdout"

--- a/moira/config.py
+++ b/moira/config.py
@@ -23,7 +23,8 @@ except ImportError:
     ujson = None
 
 CONFIG_PATH = '/etc/moira/config.yml'
-REDIS_HOST = "localhost"
+# CONFIG_PATH = '..\\pkg\\worker.yml'
+REDIS_HOST = "10.160.62.26"
 REDIS_PORT = 6379
 LOG_DIRECTORY = "stdout"
 HTTP_PORT = 8081

--- a/moira/db.py
+++ b/moira/db.py
@@ -1074,7 +1074,7 @@ class Db(service.Service):
         defer.returnValue([anyjson.deserialize(e) for e in events])
 
     @defer.inlineCallbacks
-    @docstring_parameters(TAGS)
+    @docstring_parameters(TARGETS)
     def getTargets(self):
         """
         getTargets(self)

--- a/moira/db.py
+++ b/moira/db.py
@@ -1084,12 +1084,11 @@ class Db(service.Service):
 
         :rtype: list
         """
-        variant = False
-        if variant:
+        if self.rc.exists(TARGETS):
             targets = yield self.rc.hkeys(TARGETS)
             defer.returnValue(targets)
         else:
-            targets = yield self.rc.keys("moira-metric-data*")
+            targets = yield self.rc.keys(METRIC_PREFIX.format("*"))
             defer.returnValue([target.split(":")[1] for target in targets])
 
     @defer.inlineCallbacks

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -314,3 +314,13 @@ class ApiTests(WorkerTests):
     def testUserLogin(self):
         response, user = yield self.request('GET', 'user')
         self.assertEqual('tester', user["login"])
+
+    @inlineCallbacks
+    def testTargets(self):
+        metric = "devops.functest.m"
+        yield self.db.sendMetric(metric, metric, self.now, 1)
+        response, targets = yield self.request('GET', 'targets?name=devops')
+        self.assertTrue(metric in targets["list"])
+        response, targets = yield self.request('GET', 'targets?name=badtest')
+        self.assertEqual([], targets["list"])
+        response, body = yield self.request('GET', 'targets?name1=devops', state=http.BAD_REQUEST)


### PR DESCRIPTION
Add request '_GET /api/targets?search=_' to API.
It request target's name from db. 
Default it's get data from name of **KEYS** metric data from db. Example: keys("moira-metric-data*") . 
Second way: if db has key 'moira-all-targets' with list values.
