### PR TITLE
Add delta failure test

### DIFF
--- a/moira/graphite/datalib.py
+++ b/moira/graphite/datalib.py
@@ -151,6 +151,7 @@ def fetchData(requestContext, pathExpr):
         retention = yield db.getMetricRetention(first_metric, cache_key=first_metric, cache_ttl=60)
         dataList = yield db.getMetricsValues(metrics, startTime, endTime)
         valuesList = unpackTimeSeries(dataList, retention, startTime, endTime, allowRealTimeAlerting)
+        print valuesList
         for i, metric in enumerate(metrics):
             requestContext['metrics'].add(metric)
             series = TimeSeries(


### PR DESCRIPTION
Как видно, просто добавляется 10 точек и вычисляется среднее между каждыми двумя.
Целое число любимая функция movingAverage выдавать не должна.
Специально оставлен print, чтобы видеть, что приводит к багу.